### PR TITLE
change clone command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To run Beet it's simply a case of
 
 ``` bash
 # clone
-git clone git@github.com:bitshares/beet.git
+git clone https://github.com/bitshares/beet
 cd beet
 
 # install dependencies


### PR DESCRIPTION
When i try to clone with the provided command in the README i get the error:

```
oxarbitrage@oxarbitrage-Lenovo-ideapad-320S-14IKB:~$ git clone git@github.com:bitshares/beet.git
Cloning into 'beet'...
Warning: Permanently added the RSA host key for IP address '140.82.114.4' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

This pull changes the git command and fixes the issue.